### PR TITLE
Stow probe after raising Z when homing

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -332,6 +332,7 @@ void GcodeSuite::G28() {
       // Raise Z before homing any other axes and z is not already high enough (never lower z)
       if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) by ", z_homing_height);
       do_z_clearance(z_homing_height);
+      TERN_(BLTOUCH, bltouch.init());
     }
 
     #if ENABLED(QUICK_HOME)
@@ -384,7 +385,6 @@ void GcodeSuite::G28() {
           stepper.set_separate_multi_axis(false);
         #endif
 
-        TERN_(BLTOUCH, bltouch.init());
         TERN(Z_SAFE_HOMING, home_z_safely(), homeaxis(Z_AXIS));
         probe.move_z_after_homing();
       }


### PR DESCRIPTION
### Description

This is a follow-up to #21124 where it was identified in the discussion that a BLTouch sensor may collide when homing.

Homing sequence before the PR:

1. Raise Z
2. Home X and Y
3. Stow the probe
4. Home Z

Homing sequence after the PR:

1. Raise Z
2. Stow the probe
3. Home X, Y, and Z

### Requirements

BLTouch

### Benefits

The PR may reduce probe damage caused by collision.

### Related Issues

PR #21124
